### PR TITLE
Moved /fsds/reset to fs_msgs

### DIFF
--- a/docs/ros-bridge.md
+++ b/docs/ros-bridge.md
@@ -41,7 +41,7 @@ The fsds_ros_bridge.launch launches the following nodes:
 
 ## Services
 
-- `/fsds/reset` [fsds_ros_bridge/Reset](https://github.com/FS-Driverless/Formula-Student-Driverless-Simulator/blob/master/ros/src/fsds_ros_bridge/srv/Reset.srv)   
+- `/fsds/reset` [fs_msgs/Reset](https://github.com/FS-Driverless/fs_msgs/blob/master/srv/Reset.srv)   
  Resets car to start location.
 
 ## Units

--- a/ros/src/fsds_ros_bridge/CMakeLists.txt
+++ b/ros/src/fsds_ros_bridge/CMakeLists.txt
@@ -38,17 +38,6 @@ find_package(catkin REQUIRED COMPONENTS
   fs_msgs
 )
 
-add_service_files(
-  FILES
-  Reset.srv
-)
-
-generate_messages(
-  DEPENDENCIES
-  std_msgs
-  geometry_msgs
-)
-
 catkin_package(
   INCLUDE_DIRS include
   # LIBRARIES airsim_ros

--- a/ros/src/fsds_ros_bridge/include/airsim_ros_wrapper.h
+++ b/ros/src/fsds_ros_bridge/include/airsim_ros_wrapper.h
@@ -14,7 +14,7 @@ STRICT_MODE_OFF //todo what does this do?
 #include "vehicles/car/api/CarRpcLibClient.hpp"
 #include "yaml-cpp/yaml.h"
 #include <fs_msgs/ControlCommand.h>
-#include <fsds_ros_bridge/Reset.h>
+#include <fs_msgs/Reset.h>
 #include <fs_msgs/GoSignal.h>
 #include <fs_msgs/FinishedSignal.h>
 #include <fs_msgs/Track.h>
@@ -135,7 +135,7 @@ private:
     // void set_zero_vel_cmd();
 
     /// ROS service callbacks
-    bool reset_srv_cb(fsds_ros_bridge::Reset::Request& request, fsds_ros_bridge::Reset::Response& response);
+    bool reset_srv_cb(fs_msgs::Reset::Request& request, fs_msgs::Reset::Response& response);
 
     // methods which parse setting json ang generate ros pubsubsrv
     void create_ros_pubs_from_settings_json();

--- a/ros/src/fsds_ros_bridge/src/airsim_ros_wrapper.cpp
+++ b/ros/src/fsds_ros_bridge/src/airsim_ros_wrapper.cpp
@@ -265,7 +265,7 @@ ros::Time AirsimROSWrapper::make_ts(uint64_t unreal_ts)
 
 // todo add reset by vehicle_name API to airlib
 // todo not async remove waitonlasttask
-bool AirsimROSWrapper::reset_srv_cb(fsds_ros_bridge::Reset::Request& request, fsds_ros_bridge::Reset::Response& response)
+bool AirsimROSWrapper::reset_srv_cb(fs_msgs::Reset::Request& request, fs_msgs::Reset::Response& response)
 {
     std::lock_guard<std::recursive_mutex> guard(car_control_mutex_);
 

--- a/ros/src/fsds_ros_bridge/srv/Reset.srv
+++ b/ros/src/fsds_ros_bridge/srv/Reset.srv
@@ -1,4 +1,0 @@
-# string vehicle_name
-bool waitOnLastTask 
----
-bool success


### PR DESCRIPTION
I have not renamed fs_msgs! fs_msgs now contains a service as well, however renaming would be a breaking change. I think we can stick with fs_msgs for now, maybe there is a better opportunity to rename it later on.

Fixes #251