### PR TITLE
Added big orange cones to testing_only track

### DIFF
--- a/UE4Project/Content/FormulaStudentAssets/RefereeBP.uasset
+++ b/UE4Project/Content/FormulaStudentAssets/RefereeBP.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fde10f739bf02bd90397ad08241d50518d20e6e7fd45e993f1572c21bb2b96de
-size 95161
+oid sha256:761a7638e1c9af317f8647bee8c9aab44d059146c85a741efabe72cba2ee708d
+size 92446

--- a/UE4Project/Content/FormulaStudentAssets/RefereeBP.uasset
+++ b/UE4Project/Content/FormulaStudentAssets/RefereeBP.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fdb0a922f029fa22852c1e5a0fdfae6ada0c0d0db016ac2cc4019498119748f5
-size 82086
+oid sha256:fde10f739bf02bd90397ad08241d50518d20e6e7fd45e993f1572c21bb2b96de
+size 95161

--- a/UE4Project/Content/FormulaStudentAssets/StartFinishLine.uasset
+++ b/UE4Project/Content/FormulaStudentAssets/StartFinishLine.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cb0e946cf2eb8f4ca1f851ec037be0b86c7e623235ba222f1349a5257a25e005
-size 229488
+oid sha256:810b7bc257c7c7b716344eaf05d45d0c53484cea2103c159f28d8a78b19ea39a
+size 271110

--- a/UE4Project/Plugins/AirSim/Source/Referee.cpp
+++ b/UE4Project/Plugins/AirSim/Source/Referee.cpp
@@ -56,6 +56,14 @@ void AReferee::AppendBlueCone(FTransform transform) {
 	state.cones.push_back(cone);
 }
 
+void AReferee::AppendBigOrangeCone(FTransform transform){
+	msr::airlib::CarApiBase::Cone cone;
+	cone.location.x = transform.GetTranslation().X;
+	cone.location.y = transform.GetTranslation().Y;
+	cone.color = msr::airlib::CarApiBase::ConeColor::OrangeLarge;
+	state.cones.push_back(cone);
+}
+
 void AReferee::LoadStartPos(FVector pos) {
 	msr::airlib::CarApiBase::Point2D point;
 	point.x = pos.X;

--- a/UE4Project/Plugins/AirSim/Source/Referee.h
+++ b/UE4Project/Plugins/AirSim/Source/Referee.h
@@ -41,5 +41,8 @@ public:
 	void AppendBlueCone(FTransform cone);
 
 	UFUNCTION(BlueprintCallable, Category="Referee")
+	void AppendBigOrangeCone(FTransform cone);
+
+	UFUNCTION(BlueprintCallable, Category="Referee")
 	void LoadStartPos(FVector pos);
 };


### PR DESCRIPTION
This is a solution for issue #254.

Probably not the cleanest way to do this, but I don't know much about unreal engine. Wanted to the same thing in the referee blueprint as was done with 'Track', but for some reason my reference to the start finish line never became anything else than 'None'.