### PR TITLE
Fix external camera being underground

### DIFF
--- a/UE4Project/Plugins/AirSim/Source/AirBlueprintLib.cpp
+++ b/UE4Project/Plugins/AirSim/Source/AirBlueprintLib.cpp
@@ -541,6 +541,9 @@ void UAirBlueprintLib::FollowActor(AActor* follower, const AActor* followee, con
     float dist_offset = (dist - offset_dist) / offset_dist;
     float lerp_alpha = common_utils::Utils::clip((dist_offset*dist_offset) * 0.01f + 0.01f, 0.0f, 1.0f);
     next_location = FMath::Lerp(follower->GetActorLocation(), next_location, lerp_alpha);
+
+    if (fixed_z)
+        next_location.Z = fixed_z_val;
     follower->SetActorLocation(next_location);
 
     FRotator next_rot = UKismetMathLibrary::FindLookAtRotation(follower->GetActorLocation(), followee->GetActorLocation());

--- a/UE4Project/Plugins/AirSim/Source/CameraDirector.cpp
+++ b/UE4Project/Plugins/AirSim/Source/CameraDirector.cpp
@@ -38,7 +38,7 @@ void ACameraDirector::Tick(float DeltaTime)
         //do nothing, we have camera turned off
     }
     else { //make camera move in desired way
-        UAirBlueprintLib::FollowActor(ExternalCamera, follow_actor_, initial_ground_obs_offset_, ext_obs_fixed_z_);
+        UAirBlueprintLib::FollowActor(ExternalCamera, follow_actor_, initial_ground_obs_offset_, ext_obs_fixed_z_, 400.0);
     }
 }
 


### PR DESCRIPTION
When pressing backslash ('\'), the external camera follows the car from underground, resulting in weird visual effects. This PR fixes the camera height at 4 metres above ground.