### PR TITLE
Improve wheel rpm calculation

### DIFF
--- a/UE4Project/Plugins/AirSim/Source/Vehicles/Car/CarPawnSimApi.h
+++ b/UE4Project/Plugins/AirSim/Source/Vehicles/Car/CarPawnSimApi.h
@@ -160,7 +160,7 @@ private:
     void plot(std::istream& s, FColor color, const Vector3r& offset);
     CarPawnSimApi::Pose toPose(const FVector& u_position, const FQuat& u_quat) const;
     void updateKinematics(float dt);
-    void updateWheelStates(float dt);
+    void updateWheelStates();
     void setStartPosition(const FVector& position, const FRotator& rotator);
 private:
     Params params_;


### PR DESCRIPTION
Before the code used for rpm calculations took a crude numerical derivative of wheel rotation angle, which was hacky and had potential to fail at higher rpms / lower physics update rates. The new code plugs into the internals of the vehicle simulation to retrieve wheel velocities and angles directly.