### PR TITLE
Better settings loading

### DIFF
--- a/AirSim/AirLib/include/common/Settings.hpp
+++ b/AirSim/AirLib/include/common/Settings.hpp
@@ -22,7 +22,6 @@ namespace msr { namespace airlib {
 
 class Settings {
 private:
-    std::string full_filepath_;
     nlohmann::json doc_;
 
 private:
@@ -40,8 +39,6 @@ public:
 
     static Settings& loadJSonString(const std::string& json_str)
     {
-        singleton().full_filepath_ = "";
-
         if (json_str.length() > 0) {
             std::stringstream ss;
             ss << json_str;
@@ -49,7 +46,6 @@ public:
         } else {
             throw std::invalid_argument("Invalid settings.json: json string empty.");
         }
-
         return singleton();
     }
 

--- a/AirSim/AirLib/include/common/common_utils/FileSystem.hpp
+++ b/AirSim/AirLib/include/common/common_utils/FileSystem.hpp
@@ -111,9 +111,15 @@ public:
         return fullPath;
     }
 
+    static std::string getAppDataFolder() {
+        return ensureFolder(combine(getUserHomeFolder(), ProductFolderName));
+    }
+
+    // used by the ROS bridge, should be removed once ROS bridge switches
+    // to loading the settings text via an RPC call
     static std::string getConfigFilePath()
     {
-        return combine(combine(getUserHomeFolder(), "Formula-Student-Driverless-Simulator"), "settings.json");
+        return combine(getAppDataFolder(), "settings.json");
     }
 
     static std::string getLogFileNamePath(const std::string& fullPath, const std::string& prefix, const std::string& suffix, const std::string& extension, 

--- a/UE4Project/Plugins/AirSim/Source/AirSim.Build.cs
+++ b/UE4Project/Plugins/AirSim/Source/AirSim.Build.cs
@@ -75,7 +75,7 @@ public class AirSim : ModuleRules
 
         bEnableExceptions = true;
 
-        PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "ImageWrapper", "RenderCore", "RHI", "PhysXVehicles", "PhysicsCore", "PhysXVehicleLib", "PhysX", "APEX", "Landscape" });
+        PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "HTTP", "InputCore", "ImageWrapper", "RenderCore", "RHI", "PhysXVehicles", "PhysicsCore", "PhysXVehicleLib", "PhysX", "APEX", "Landscape" });
         PrivateDependencyModuleNames.AddRange(new string[] { "UMG", "Slate", "SlateCore" });
 
         //suppress VC++ proprietary warnings

--- a/UE4Project/Plugins/AirSim/Source/AirSimGameMode.h
+++ b/UE4Project/Plugins/AirSim/Source/AirSimGameMode.h
@@ -30,7 +30,11 @@ public:
     
 private:
     void initializeSettings();
-    void readSettingsTextFromFile(FString fileName, std::string& settingsText);
+    bool getSettingsText(FString& settingsTextOutput);
+    bool readSettingsTextFromFile(std::string fileName, FString& settingsTextOutput);
+    bool readSettingsTextFromFile(FString fileName, FString& settingsTextOutput);
+    bool getSettingsTextFromCommandLine(FString& settingsTextOutput);
+    bool parseSettingsStringFromCommandLine(FString maybeQuotedString, FString& settingsTextOutput);
 
     void setUnrealEngineSettings();
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -17,9 +17,19 @@ For developing this project, you need quite a good computer because Unreal Engin
 If your computer does not suffice you can use a remote workstation on Google Cloud Platform.
 Read [this tutorial](gcp-remote-workstation.md) on how to setup your virtual workstation.
 
-The simulator will load settings from the file `Formula-Student-Driverless-Simulator/settings.json` in your **home directory**.
-This file is required for the simulator to work and contains the sensor configuration of the car.
-If you clone the repo you will already have this file in place.
+## Settings
+
+In order to work, the simulator requires a `settings.json` file, which contains general settings and the sensor configuration of the car.
+The simulator will look for this file in the following places:
+- `~/Formula-Student-Driverless-Simulator/settings.json` in your **home directory**,
+- The folder the simulator binary is located in (`<the folder with FSDS.sh>/FSOnline/Binaries/<your OS>/`). 
+- The current working directory when the simulator binary is launched
+- The path supplied via the `-settings "<path to settings.json file>` command line argument to the binary
+
+Alternatively, when programatically generating the setttings, the simulator also accepts
+the settings as a URL encoded json string (e.g. `-settings "%7B%22SeeDocsAt%22%3A%22https%....`)
+
+If you cloned the repo in your home directory you will already have this file in place.
 If not, copy-paste the contents of the [settings.json file at the root of this repository](https://github.com/FS-Driverless/Formula-Student-Driverless-Simulator/blob/master/settings.json) into the `~/Formula-Student-Driverless-Simulator`.
 This should get you started with the default vehicle and sensor configuration, but feel free to try your own custom sensor suite.
 The default vehicle is the Technion Formula Student racing car, but teams participating in the UK edition of FS-AI might want


### PR DESCRIPTION
Add abilities to load settings.json from 
- the same folder the game binary is in, 
- the current working directory from which the binary is launched
- a path specified by the `-settings "<absolute path to a settings.json file>"` command line argument
- directly from the value of the `-settings "<URL encoded string>"` command line argument, as a URL encoded json string

Closes #309 