### PR TITLE
ROS2 Humble compatibility

### DIFF
--- a/ros2/src/fsds_ros2_bridge/include/airsim_ros_wrapper.h
+++ b/ros2/src/fsds_ros2_bridge/include/airsim_ros_wrapper.h
@@ -230,6 +230,7 @@ private:
 	std::shared_ptr<rclcpp::Publisher<rosgraph_msgs::msg::Clock>> clock_pub;
     
     /// ROS subscribers
-    std::shared_ptr<rclcpp::Subscription<std::remove_cv_t<std::remove_reference_t<const fs_msgs::msg::ControlCommand &>>, std::allocator<void>, rclcpp::message_memory_strategy::MessageMemoryStrategy<std::remove_cv_t<std::remove_reference_t<const fs_msgs::msg::ControlCommand &>>, std::allocator<void>>>> control_cmd_sub;
+    // std::shared_ptr<rclcpp::Subscription<std::remove_cv_t<std::remove_reference_t<const fs_msgs::msg::ControlCommand &>>, std::allocator<void>, rclcpp::message_memory_strategy::MessageMemoryStrategy<std::remove_cv_t<std::remove_reference_t<const fs_msgs::msg::ControlCommand &>>, std::allocator<void>>>> control_cmd_sub;
+    rclcpp::Subscription<fs_msgs::msg::ControlCommand>::SharedPtr control_cmd_sub;
     rclcpp::Subscription<fs_msgs::msg::FinishedSignal>::SharedPtr finished_signal_sub_;
 };

--- a/ros2/src/fsds_ros2_bridge/include/airsim_ros_wrapper.h
+++ b/ros2/src/fsds_ros2_bridge/include/airsim_ros_wrapper.h
@@ -39,11 +39,11 @@ STRICT_MODE_OFF //todo what does this do?
 #include <sensor_msgs/msg/imu.hpp>
 #include <sensor_msgs/msg/nav_sat_fix.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
-#include <std_srvs/srv/empty.hpp>
+// #include <std_srvs/srv/empty.hpp>
 // #include <tf/tf.h>
 #include <tf2/LinearMath/Matrix3x3.h>
 #include <tf2/LinearMath/Quaternion.h>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+// #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include <tf2_ros/static_transform_broadcaster.h>
 #include <tf2_ros/transform_broadcaster.h>
 #include <tf2_ros/transform_listener.h>

--- a/ros2/src/fsds_ros2_bridge/include/airsim_ros_wrapper.h
+++ b/ros2/src/fsds_ros2_bridge/include/airsim_ros_wrapper.h
@@ -39,11 +39,9 @@ STRICT_MODE_OFF //todo what does this do?
 #include <sensor_msgs/msg/imu.hpp>
 #include <sensor_msgs/msg/nav_sat_fix.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
-// #include <std_srvs/srv/empty.hpp>
 // #include <tf/tf.h>
 #include <tf2/LinearMath/Matrix3x3.h>
 #include <tf2/LinearMath/Quaternion.h>
-// #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include <tf2_ros/static_transform_broadcaster.h>
 #include <tf2_ros/transform_broadcaster.h>
 #include <tf2_ros/transform_listener.h>
@@ -230,7 +228,6 @@ private:
 	std::shared_ptr<rclcpp::Publisher<rosgraph_msgs::msg::Clock>> clock_pub;
     
     /// ROS subscribers
-    // std::shared_ptr<rclcpp::Subscription<std::remove_cv_t<std::remove_reference_t<const fs_msgs::msg::ControlCommand &>>, std::allocator<void>, rclcpp::message_memory_strategy::MessageMemoryStrategy<std::remove_cv_t<std::remove_reference_t<const fs_msgs::msg::ControlCommand &>>, std::allocator<void>>>> control_cmd_sub;
     rclcpp::Subscription<fs_msgs::msg::ControlCommand>::SharedPtr control_cmd_sub;
     rclcpp::Subscription<fs_msgs::msg::FinishedSignal>::SharedPtr finished_signal_sub_;
 };

--- a/ros2/src/fsds_ros2_bridge/src/airsim_ros_wrapper.cpp
+++ b/ros2/src/fsds_ros2_bridge/src/airsim_ros_wrapper.cpp
@@ -199,9 +199,9 @@ void AirsimROSWrapper::create_ros_pubs_from_settings_json()
         nh_->get_parameter("UDP_control", UDP_control);
 
         if(UDP_control){
-            auto control_cmd_sub = nh_->create_subscription<fs_msgs::msg::ControlCommand>("control_command", 1, std::bind(&AirsimROSWrapper::car_control_cb, this, std::placeholders::_1));
+            control_cmd_sub = nh_->create_subscription<fs_msgs::msg::ControlCommand>("control_command", 1, std::bind(&AirsimROSWrapper::car_control_cb, this, std::placeholders::_1));
         } else {
-            auto control_cmd_sub = nh_->create_subscription<fs_msgs::msg::ControlCommand>("control_command", 1, std::bind(&AirsimROSWrapper::car_control_cb, this, std::placeholders::_1));
+            control_cmd_sub = nh_->create_subscription<fs_msgs::msg::ControlCommand>("control_command", 1, std::bind(&AirsimROSWrapper::car_control_cb, this, std::placeholders::_1));
         }
 
         if(!competition_mode_) {

--- a/ros2/src/fsds_ros2_bridge/src/airsim_ros_wrapper.cpp
+++ b/ros2/src/fsds_ros2_bridge/src/airsim_ros_wrapper.cpp
@@ -199,9 +199,9 @@ void AirsimROSWrapper::create_ros_pubs_from_settings_json()
         nh_->get_parameter("UDP_control", UDP_control);
 
         if(UDP_control){
-            control_cmd_sub = nh_->create_subscription<fs_msgs::msg::ControlCommand>("control_command", 1, std::bind(&AirsimROSWrapper::car_control_cb, this, std::placeholders::_1));
+            auto control_cmd_sub = nh_->create_subscription<fs_msgs::msg::ControlCommand>("control_command", 1, std::bind(&AirsimROSWrapper::car_control_cb, this, std::placeholders::_1));
         } else {
-            control_cmd_sub = nh_->create_subscription<fs_msgs::msg::ControlCommand>("control_command", 1, std::bind(&AirsimROSWrapper::car_control_cb, this, std::placeholders::_1));
+            auto control_cmd_sub = nh_->create_subscription<fs_msgs::msg::ControlCommand>("control_command", 1, std::bind(&AirsimROSWrapper::car_control_cb, this, std::placeholders::_1));
         }
 
         if(!competition_mode_) {


### PR DESCRIPTION
This has been tested on Humble and Galactic in Ubuntu 20.04, WSL2.
These were problematic lines stopping the bridge from `colcon` building in Humble, but maintains backwards compatibility.

As mentioned in https://github.com/FS-Driverless/Formula-Student-Driverless-Simulator/issues/296 there may be further compatibility issues with Ubuntu 22.04 that can be addressed in a future PR.