### PR TITLE
Fix linux compilation warnings

### DIFF
--- a/UE4Project/Plugins/AirSim/Source/AirBlueprintLib.cpp
+++ b/UE4Project/Plugins/AirSim/Source/AirBlueprintLib.cpp
@@ -371,8 +371,8 @@ std::vector<msr::airlib::MeshPositionVertexBuffersResponse> UAirBlueprintLib::Ge
 
         //Various checks if there is even a valid mesh
         if (!comp->GetStaticMesh()) continue;
-        if (!comp->GetStaticMesh()->RenderData) continue;
-        if (comp->GetStaticMesh()->RenderData->LODResources.Num() == 0) continue;
+        if (!comp->GetStaticMesh()->GetRenderData()) continue;
+        if (comp->GetStaticMesh()->GetRenderData()->LODResources.Num() == 0) continue;
 
         msr::airlib::MeshPositionVertexBuffersResponse mesh;
         mesh.name = name;
@@ -387,7 +387,7 @@ std::vector<msr::airlib::MeshPositionVertexBuffersResponse> UAirBlueprintLib::Ge
         mesh.orientation.y() = att.Y;
         mesh.orientation.z() = att.Z;
 
-        FPositionVertexBuffer* vertex_buffer = &comp->GetStaticMesh()->RenderData->LODResources[0].VertexBuffers.PositionVertexBuffer;
+        FPositionVertexBuffer* vertex_buffer = &comp->GetStaticMesh()->GetRenderData()->LODResources[0].VertexBuffers.PositionVertexBuffer;
         if (vertex_buffer)
         {
             const int32 vertex_count = vertex_buffer->VertexBufferRHI->GetSize();
@@ -403,7 +403,7 @@ std::vector<msr::airlib::MeshPositionVertexBuffersResponse> UAirBlueprintLib::Ge
                     RHIUnlockVertexBuffer(vertex_buffer->VertexBufferRHI);
                 });
 
-            FStaticMeshLODResources& lod = comp->GetStaticMesh()->RenderData->LODResources[0];
+            FStaticMeshLODResources& lod = comp->GetStaticMesh()->GetRenderData()->LODResources[0];
             FRawStaticIndexBuffer* IndexBuffer = &lod.IndexBuffer;
             int num_indices = IndexBuffer->IndexBufferRHI->GetSize() / IndexBuffer->IndexBufferRHI->GetStride();
 

--- a/UE4Project/Plugins/AirSim/Source/AirSim.Build.cs
+++ b/UE4Project/Plugins/AirSim/Source/AirSim.Build.cs
@@ -101,13 +101,6 @@ public class AirSim : ModuleRules
             PublicAdditionalLibraries.Add("dinput8.lib");
             PublicAdditionalLibraries.Add("dxguid.lib");
         }
-
-		if (Target.Platform == UnrealTargetPlatform.Linux)
-		{
-			// needed when packaging
-			PublicAdditionalLibraries.Add("stdc++");
-			PublicAdditionalLibraries.Add("supc++");
-		}
     }
 
     static void CopyFileIfNewer(string srcFilePath, string destFolder)


### PR DESCRIPTION
This fixes the 
- ```WARNING: Library ‘stdc++’ was not resolvable to a file when used in Module ‘AirSim’, assuming it is a filename and will search library paths for it. This is slow and dependency checking will not work for it. Please update reference to be fully qualified alternatively use Public System Library Paths if you do intended to use this slow path to suppress this warning.``` warning by removing the unneeded dependency declarations on `stdc++` and `supc++`,

- ```RenderData is deprecated. Please use GetRenderData() instead``` warning by doing what it says to do.

I've verified that the project still compiles and packages succesfully on linux, and it certainly does too on windows