### PR TITLE
Ros use same settings as airsim

### DIFF
--- a/AirSim/AirLib/include/api/RpcLibClientBase.hpp
+++ b/AirSim/AirLib/include/api/RpcLibClientBase.hpp
@@ -101,7 +101,7 @@ public:
     msr::airlib::WheelStates simGetWheelStates(const std::string& vehicle_name = "") const;
 
 	std::vector<std::string> simSwapTextures(const std::string& tags, int tex_id = 0, int component_id = 0, int material_id = 0);
-
+    std::string getSettingsString() const;
 protected:
     void* getClient();
     const void* getClient() const;

--- a/AirSim/AirLib/include/api/WorldSimApiBase.hpp
+++ b/AirSim/AirLib/include/api/WorldSimApiBase.hpp
@@ -60,6 +60,7 @@ public:
 
 	virtual std::unique_ptr<std::vector<std::string>> swapTextures(const std::string& tag, int tex_id = 0, int component_id = 0, int material_id = 0) = 0;
     virtual vector<MeshPositionVertexBuffersResponse> getMeshPositionVertexBuffers() const = 0;
+    virtual std::string getSettingsString() const = 0;
 };
 
 

--- a/AirSim/AirLib/include/common/AirSimSettings.hpp
+++ b/AirSim/AirLib/include/common/AirSimSettings.hpp
@@ -328,6 +328,8 @@ public: //fields
 	std::string speed_unit_label = "m\\s";
     std::map<std::string, std::unique_ptr<SensorSetting>> sensor_defaults;
 
+    std::string settings_text_ = "";
+
 public: //methods
     static AirSimSettings& singleton()
     {
@@ -367,6 +369,7 @@ public: //methods
     static void initializeSettings(const std::string& json_settings_text)
     {
         try {
+            singleton().settings_text_ = json_settings_text;
             Settings::loadJSonString(json_settings_text);
         }
         catch (std::exception &ex) {

--- a/AirSim/AirLib/src/api/RpcLibClientBase.cpp
+++ b/AirSim/AirLib/src/api/RpcLibClientBase.cpp
@@ -366,6 +366,10 @@ void RpcLibClientBase::cancelLastTask(const std::string& vehicle_name)
 {
     pimpl_->client.call("cancelLastTask", vehicle_name);
 }
+std::string RpcLibClientBase::getSettingsString() const
+{
+    return pimpl_->client.call("getSettingsString").as<std::string>();
+}
 
 //return value of last task. It should be true if task completed without
 //cancellation or timeout

--- a/AirSim/AirLib/src/api/RpcLibServerBase.cpp
+++ b/AirSim/AirLib/src/api/RpcLibServerBase.cpp
@@ -89,6 +89,9 @@ RpcLibServerBase::RpcLibServerBase(ApiProvider* api_provider, const std::string&
     pimpl_->server.bind("getMinRequiredClientVersion", []() -> int {
         return 1;
     });
+     pimpl_->server.bind("getSettingsString", [&]() -> std::string {
+        return getWorldSimApi()->getSettingsString();
+    });
        
     pimpl_->server.bind("simPause", [&](bool is_paused) -> void { 
         getWorldSimApi()->pause(is_paused); 

--- a/UE4Project/Plugins/AirSim/Source/WorldSimApi.cpp
+++ b/UE4Project/Plugins/AirSim/Source/WorldSimApi.cpp
@@ -249,3 +249,8 @@ std::vector<WorldSimApi::MeshPositionVertexBuffersResponse> WorldSimApi::getMesh
 	}, true);
 	return responses;
 }
+
+std::string WorldSimApi::getSettingsString() const
+{
+    return msr::airlib::AirSimSettings::singleton().settings_text_;
+}

--- a/UE4Project/Plugins/AirSim/Source/WorldSimApi.h
+++ b/UE4Project/Plugins/AirSim/Source/WorldSimApi.h
@@ -49,6 +49,7 @@ public:
     virtual void simPlotTransforms(const std::vector<Pose>& poses, float scale, float thickness, float duration, bool is_persistent) override;
     virtual void simPlotTransformsWithNames(const std::vector<Pose>& poses, const std::vector<std::string>& names, float tf_scale, float tf_thickness, float text_scale, const std::vector<float>& text_color_rgba, float duration) override;
 	virtual std::vector<MeshPositionVertexBuffersResponse> getMeshPositionVertexBuffers() const override;
+    virtual std::string getSettingsString() const override;
 
 private:
     ASimModeBase* simmode_;

--- a/python/fsds/client.py
+++ b/python/fsds/client.py
@@ -197,3 +197,11 @@ class FSDSClient:
     def getRefereeState(self):
         referee_state_raw = self.client.call('getRefereeState')
         return RefereeState.from_msgpack(referee_state_raw)
+
+    def getSettingsString(self):
+        """
+        Fetch the settings text being used by AirSim
+        Returns:
+            str: Settings text in JSON format
+        """
+        return self.client.call('getSettingsString')

--- a/ros/src/fsds_ros_bridge/src/airsim_ros_wrapper.cpp
+++ b/ros/src/fsds_ros_bridge/src/airsim_ros_wrapper.cpp
@@ -11,8 +11,9 @@ AirsimROSWrapper::AirsimROSWrapper(const ros::NodeHandle& nh, const ros::NodeHan
                                                                                                                                airsim_client_lidar_(host_ip)
 {
     try {
-        auto settingsText = this->readTextFromFile(common_utils::FileSystem::getConfigFilePath());
-        msr::airlib::AirSimSettings::initializeSettings(settingsText);
+        airsim_client_.confirmConnection();
+        std::string settings_text = airsim_client_.getSettingsString();
+        msr::airlib::AirSimSettings::initializeSettings(settings_text);
 
         msr::airlib::AirSimSettings::singleton().load();
         for (const auto &warning : msr::airlib::AirSimSettings::singleton().warning_messages)

--- a/ros2/src/fsds_ros2_bridge/src/airsim_ros_wrapper.cpp
+++ b/ros2/src/fsds_ros2_bridge/src/airsim_ros_wrapper.cpp
@@ -13,8 +13,9 @@ AirsimROSWrapper::AirsimROSWrapper(const std::shared_ptr<rclcpp::Node>& nh, cons
                                                                                                     static_tf_pub_(this->nh_)
 {
     try {
-        auto settingsText = this->readTextFromFile(common_utils::FileSystem::getConfigFilePath());
-        msr::airlib::AirSimSettings::initializeSettings(settingsText);
+        airsim_client_.confirmConnection();
+        std::string settings_text = airsim_client_.getSettingsString();
+        msr::airlib::AirSimSettings::initializeSettings(settings_text);
 
         msr::airlib::AirSimSettings::singleton().load();
         for (const auto &warning : msr::airlib::AirSimSettings::singleton().warning_messages)


### PR DESCRIPTION
Instead of reading the settings.json from a file, the ROS bridge will obtain the settings from AirSim via RPC. This is needed because AirSim no longer looks for settings.json in one place, and possibly reads it from command line, so ROS bridge couldn't access it in any other way.

Closes #308