### PR TITLE
Add waiting for RPC server to become available

### DIFF
--- a/AirSim/AirLib/include/api/RpcLibClientBase.hpp
+++ b/AirSim/AirLib/include/api/RpcLibClientBase.hpp
@@ -26,7 +26,7 @@ public:
     RpcLibClientBase(const string& ip_address = "localhost", uint16_t port = RpcLibPort, float timeout_sec = 60);
     virtual ~RpcLibClientBase();    //required for pimpl
 
-    void confirmConnection();
+    void confirmConnection(double timeout);
     void reset();
 
     ConnectionState getConnectionState();
@@ -107,6 +107,10 @@ protected:
     const void* getClient() const;
 
 private:
+    std::string ip_address_;
+    uint16_t port_;
+    float timeout_sec_;
+
     struct impl;
     std::unique_ptr<impl> pimpl_;
 };

--- a/ros/src/fsds_ros_bridge/include/airsim_ros_wrapper.h
+++ b/ros/src/fsds_ros_bridge/include/airsim_ros_wrapper.h
@@ -77,7 +77,7 @@ public:
     AirsimROSWrapper(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private, const std::string& host_ip);
     ~AirsimROSWrapper(){};
 
-    void initialize_airsim();
+    void initialize_airsim(TTimeDelta timeout);
     void initialize_ros();
     void publish_track();
     void initialize_statistics();

--- a/ros/src/fsds_ros_bridge/include/airsim_ros_wrapper.h
+++ b/ros/src/fsds_ros_bridge/include/airsim_ros_wrapper.h
@@ -74,7 +74,7 @@ struct SimpleMatrix
 class AirsimROSWrapper
 {
 public:
-    AirsimROSWrapper(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private, const std::string& host_ip);
+    AirsimROSWrapper(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private, const std::string& host_ip, double timeout_sec);
     ~AirsimROSWrapper(){};
 
     void initialize_airsim(TTimeDelta timeout);

--- a/ros/src/fsds_ros_bridge/include/airsim_ros_wrapper.h
+++ b/ros/src/fsds_ros_bridge/include/airsim_ros_wrapper.h
@@ -77,7 +77,7 @@ public:
     AirsimROSWrapper(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private, const std::string& host_ip, double timeout_sec);
     ~AirsimROSWrapper(){};
 
-    void initialize_airsim(TTimeDelta timeout);
+    void initialize_airsim(double timeout);
     void initialize_ros();
     void publish_track();
     void initialize_statistics();

--- a/ros/src/fsds_ros_bridge/scripts/cameralauncher.py
+++ b/ros/src/fsds_ros_bridge/scripts/cameralauncher.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import roslaunch
 from os.path import expanduser
 import json 

--- a/ros/src/fsds_ros_bridge/src/airsim_ros_wrapper.cpp
+++ b/ros/src/fsds_ros_bridge/src/airsim_ros_wrapper.cpp
@@ -12,10 +12,11 @@ AirsimROSWrapper::AirsimROSWrapper(const ros::NodeHandle& nh, const ros::NodeHan
 {
     initialize_airsim(timeout_sec);
     try {
-        airsim_client_.confirmConnection();
+        ROS_INFO_STREAM("READING SETTINGS");
         std::string settings_text = airsim_client_.getSettingsString();
-        msr::airlib::AirSimSettings::initializeSettings(settings_text);
+        ROS_INFO_STREAM("SETTINGS READ");
 
+        msr::airlib::AirSimSettings::initializeSettings(settings_text);
         msr::airlib::AirSimSettings::singleton().load();
         for (const auto &warning : msr::airlib::AirSimSettings::singleton().warning_messages)
         {

--- a/ros/src/fsds_ros_bridge/src/fsds_ros_bridge.cpp
+++ b/ros/src/fsds_ros_bridge/src/fsds_ros_bridge.cpp
@@ -9,8 +9,11 @@ int main(int argc, char ** argv)
     ros::NodeHandle nh_private("~");
 
     std::string host_ip = "localhost";
+    double timeout_sec = 10;
     nh_private.getParam("host_ip", host_ip);
-    AirsimROSWrapper airsim_ros_wrapper(nh, nh_private, host_ip);
+    nh_private.getParam("timeout", timeout_sec);
+
+    AirsimROSWrapper airsim_ros_wrapper(nh, nh_private, host_ip, timeout_sec);
 
     if (airsim_ros_wrapper.is_used_lidar_timer_cb_queue_)
     {

--- a/ros/src/fsds_ros_bridge/src/fsds_ros_bridge_camera.cpp
+++ b/ros/src/fsds_ros_bridge/src/fsds_ros_bridge_camera.cpp
@@ -162,9 +162,12 @@ int main(int argc, char ** argv)
     msr::airlib::CarRpcLibClient client(host_ip, RpcLibPort, 5);
     airsim_api = &client;
 
+    double timeout_sec = 10.0;
+    nh.getParam("timeout", timeout_sec);
+
     try {
         std::cout << "Waiting for connection - " << std::endl;
-        airsim_api->confirmConnection();
+        airsim_api->confirmConnection(timeout_sec);
         std::cout << "Connected to the simulator!" << std::endl;
     } catch (const std::exception &e) {
         std::string msg = e.what();

--- a/ros2/src/fsds_ros2_bridge/include/airsim_ros_wrapper.h
+++ b/ros2/src/fsds_ros2_bridge/include/airsim_ros_wrapper.h
@@ -75,10 +75,10 @@ struct SimpleMatrix
 class AirsimROSWrapper
 {
 public:
-    AirsimROSWrapper(const std::shared_ptr<rclcpp::Node>& nh, const std::string& host_ip);
+    AirsimROSWrapper(const std::shared_ptr<rclcpp::Node>& nh, const std::string& host_ip, double timeout_sec);
     ~AirsimROSWrapper(){};
 
-    void initialize_airsim();
+    void initialize_airsim(double timeout_sec);
     void initialize_ros();
     void publish_track();
     void initialize_statistics();
@@ -182,6 +182,7 @@ private:
     bool competition_mode_;
     rclcpp::Time go_timestamp_;
 
+    std::string host_ip_;
     msr::airlib::CarRpcLibClient airsim_client_;
     msr::airlib::CarRpcLibClient airsim_client_lidar_;
 

--- a/ros2/src/fsds_ros2_bridge/src/fsds_ros2_bridge.cpp
+++ b/ros2/src/fsds_ros2_bridge/src/fsds_ros2_bridge.cpp
@@ -8,8 +8,9 @@ int main(int argc, char ** argv)
     std::shared_ptr<rclcpp::Node> node = rclcpp::Node::make_shared("fsds_ros2_bridge"); 
 
     std::string host_ip = node->declare_parameter<std::string>("host_ip", "localhost");
+    double timeout_sec = node->declare_parameter<double>("timeout", 10.0);
 
-    AirsimROSWrapper airsim_ros_wrapper(node, host_ip);
+    AirsimROSWrapper airsim_ros_wrapper(node, host_ip, timeout_sec);
 
     // if (airsim_ros_wrapper.is_used_lidar_timer_cb_queue_)
     // {

--- a/ros2/src/fsds_ros2_bridge/src/fsds_ros2_bridge_camera.cpp
+++ b/ros2/src/fsds_ros2_bridge/src/fsds_ros2_bridge_camera.cpp
@@ -188,9 +188,11 @@ int main(int argc, char ** argv)
     msr::airlib::CarRpcLibClient client(host_ip, RpcLibPort, 5);
     airsim_api = &client;
 
+    double timeout_sec = nh->declare_parameter<double>("timeout", 10.0);
+
     try {
         std::cout << "Waiting for connection - " << std::endl;
-        airsim_api->confirmConnection();
+        airsim_api->confirmConnection(timeout_sec);
         std::cout << "Connected to the simulator!" << std::endl;
     } catch (const std::exception &e) {
         std::string msg = e.what();


### PR DESCRIPTION
I've encountered an issue where if the ros bridge and the simulator are launched simultaneously, but the simulator takes longer to load, then ros bridge exits with an error saying that it could not connect. I thought that it would be better to wait a configurable amount of time for the simulator to load, so I've added this to the ROS2 bridge. @wouter-heerwegh, could you copy and test the changes for ROS1? Should be quick, the change is really small.

The ROS parameter `timeout` will control how much time to wait for the RPC server (simulator) to become available