### PR TITLE
Matching rpclib to repo's directory

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "ros/src/fs_msgs"]
 	path = ros/src/fs_msgs
 	url = https://github.com/FS-Driverless/fs_msgs.git
-[submodule "AirSim/AirLib/external/rpclib"]
+[submodule "AirSim/external/rpclib"]
 	path = AirSim/external/rpclib
 	url = https://github.com/rpclib/rpclib.git
 [submodule "ros2/src/fs_msgs"]

--- a/ros2/src/fsds_ros2_bridge/CMakeLists.txt
+++ b/ros2/src/fsds_ros2_bridge/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.18)
 project(fsds_ros2_bridge)
 
 # set this to path to AirSim root folder if you want your catkin workspace in a custom directory
-set(AIRSIM_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../../AirSim/)
+set(AIRSIM_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../../AirSim)
 
 add_subdirectory("${AIRSIM_ROOT}/cmake/rpclib_wrapper" rpclib_wrapper)
 add_subdirectory("${AIRSIM_ROOT}/cmake/AirLib" AirLib)
@@ -14,7 +14,7 @@ set(CXX_EXP_LIB "-nostdinc++ -I/usr/include/c++/8 -I/usr/include/x86_64-linux-gn
 -lm -lc -lgcc_s -lgcc  
 -lstdc++fs -fmax-errors=10 -Wnoexcept -Wstrict-null-sentinel") 
 
-set(RPC_LIB_INCLUDES " ${AIRSIM_ROOT}/external/rpclib/rpclib-2.2.1/include")
+set(RPC_LIB_INCLUDES " ${AIRSIM_ROOT}/external/rpclib/include")
 set(RPC_LIB rpc) # name of .a file with lib prefix
 message(STATUS "found RPC_LIB_INCLUDES=${RPC_LIB_INCLUDES}")
 


### PR DESCRIPTION
Not sure if this has been affecting ppl but I was resetting some of my branches and this got in the way.
The directory says `external` is within `Airsim` not `Airsim/Airlib`