### PR TITLE
Fix drifting

### DIFF
--- a/UE4Project/Plugins/AirSim/Content/VehicleAdv/Cars/AdsDv/AdsDv_Pawn.uasset
+++ b/UE4Project/Plugins/AirSim/Content/VehicleAdv/Cars/AdsDv/AdsDv_Pawn.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:056ce97ed4ad96140b68376dd1ca1fba424156eb0bb966029a8591554bfda5b5
-size 200686
+oid sha256:7ba4c0e112d2a5660a9e0248f1ee4466a3f9cf696f001dfca7eb37f8024e15ae
+size 200759

--- a/UE4Project/Plugins/AirSim/Content/VehicleAdv/Cars/TechnionCar/TechnionCarPawn.uasset
+++ b/UE4Project/Plugins/AirSim/Content/VehicleAdv/Cars/TechnionCar/TechnionCarPawn.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4f71bf2738796b9337e4a1bf56af368b54edd65eed1c64b794caad28aff41460
-size 191913
+oid sha256:5a170e5243d9587e815b274cd3c0a2ad4a9bc03845d3e0f6f417c194cca8ec9c
+size 192110


### PR DESCRIPTION
Fixes #334 for both the technion and FSAI vehicle.

I also added a gear ratio of -1 for the FSAI vehicle, as this is nice for debugging. It is not possible to reverse using the python API or ROS bridges.