### PR TITLE
Change camera prefix to follow documentation and to follow lidar naming convention

### DIFF
--- a/ros/src/fsds_ros_bridge/src/fsds_ros_bridge_camera.cpp
+++ b/ros/src/fsds_ros_bridge/src/fsds_ros_bridge_camera.cpp
@@ -144,7 +144,7 @@ int main(int argc, char ** argv)
 
     // load settings
     nh.param<std::string>("camera_name", camera_name, "");
-    nh.param<std::string>("camera_frame_prefix", camera_frame_prefix, "/fsds/");
+    nh.param<std::string>("camera_frame_prefix", camera_frame_prefix, "/fsds/camera");
     camera_frame_id = camera_frame_prefix + camera_name;
 
     nh.param<double>("framerate", framerate, 0.0);

--- a/ros2/src/fsds_ros2_bridge/src/fsds_ros2_bridge_camera.cpp
+++ b/ros2/src/fsds_ros2_bridge/src/fsds_ros2_bridge_camera.cpp
@@ -170,7 +170,7 @@ int main(int argc, char ** argv)
 
     // load settings
     camera_name = nh->declare_parameter<std::string>("camera_name", "");
-    camera_frame_prefix = nh->declare_parameter<std::string>("camera_frame_prefix", "/fsds/");
+    camera_frame_prefix = nh->declare_parameter<std::string>("camera_frame_prefix", "/fsds/camera");
     camera_frame_id = camera_frame_prefix + camera_name;
 
     framerate = nh->declare_parameter<double>("framerate", 0.0);


### PR DESCRIPTION
Fixes #355