### PR TITLE
Fix absolute path problem in launch file

### DIFF
--- a/ros2/src/fsds_ros2_bridge/launch/fsds_ros2_bridge.launch.py
+++ b/ros2/src/fsds_ros2_bridge/launch/fsds_ros2_bridge.launch.py
@@ -1,18 +1,22 @@
+import os
+
 import launch
 import launch_ros.actions
 
-from os.path import expanduser
-import json 
+import json
+import re
 
 CAMERA_FRAMERATE = 30.0
 
+
 def generate_launch_description():
-    with open(expanduser("~")+'/Formula-Student-Driverless-Simulator/settings.json', 'r') as file:
+    with open(re.sub('ros2/install/fsds_ros2_bridge/share/fsds_ros2_bridge/launch', 'settings.json',
+                     os.path.dirname(__file__)), 'r') as file:
         settings = json.load(file)
 
     camera_configs = settings['Vehicles']['FSCar']['Cameras']
-    if(not camera_configs):
-        print('no cameras configured in ~/Formula-Student-Driverless-Simulator/settings.json')
+    if not camera_configs:
+        print('no cameras configured in settings.json')
 
     camera_nodes = [
         launch_ros.actions.Node(


### PR DESCRIPTION
This is a suggestion, how the problem with the absolute path can be fixed for ros2. With this solution it should be possible to run the simulator with ros2 in every directory