### PR TITLE
ROS2 Namespace and testing_only/track latching

### DIFF
--- a/ros2/src/fsds_ros2_bridge/launch/fsds_ros2_bridge.launch.py
+++ b/ros2/src/fsds_ros2_bridge/launch/fsds_ros2_bridge.launch.py
@@ -60,6 +60,7 @@ def generate_launch_description():
             package='fsds_ros2_bridge',
             executable='fsds_ros2_bridge',
             name='ros_bridge',
+            namespace='fsds',
             output='screen',
             on_exit=launch.actions.Shutdown(),
             parameters=[

--- a/ros2/src/fsds_ros2_bridge/src/airsim_ros_wrapper.cpp
+++ b/ros2/src/fsds_ros2_bridge/src/airsim_ros_wrapper.cpp
@@ -246,7 +246,7 @@ void AirsimROSWrapper::create_ros_pubs_from_settings_json()
 
         if(!competition_mode_) {
             odom_pub = nh_->create_publisher<nav_msgs::msg::Odometry>("testing_only/odom", 10);
-            track_pub = nh_->create_publisher<fs_msgs::msg::Track>("testing_only/track", 10);
+            track_pub = nh_->create_publisher<fs_msgs::msg::Track>("testing_only/track", rclcpp::QoS(10).transient_local());
 			extra_info_pub = nh_->create_publisher<fs_msgs::msg::ExtraInfo>("testing_only/extra_info", 10);
         }
         


### PR DESCRIPTION
I'm finally porting my personal code to ROS2, I saw that `/fsds/` was never prepended to any topic (while it is in ROS1).

I added the fsds namespace to the bridge node to align with the documentation and ROS1 and also made `testing_only/track` transient local. If your subscriber is also transient local, it should act like a latching topic now. This fixes #367.